### PR TITLE
Fixed poster name of Rahat

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -10,7 +10,7 @@ layout: "base.html"
 IEEE VIS is the premier forum for advances in theory, methods, and applications of visualization and visual analytics.
 
 <div>
- <img src="/assets/gator_satellite.png" style="max-width: 100%"/>
+ <img src="/assets/gator_satellite.png" style="max-width: 20%; width: 200px;"/>
 </div>
 
 ## Satellite Event

--- a/src/index.md
+++ b/src/index.md
@@ -10,7 +10,7 @@ layout: "base.html"
 IEEE VIS is the premier forum for advances in theory, methods, and applications of visualization and visual analytics.
 
 <div>
- <img src="/assets/gator_satellite.png" style="max-width: 20%; width: 200px;"/>
+ <img src="/assets/gator_satellite.png" style="max-width: 200px; width: 20%;"/>
 </div>
 
 ## Satellite Event

--- a/src/index.md
+++ b/src/index.md
@@ -66,7 +66,7 @@ Posters
 3. Vispubs.com: A Visualization Publications Repository. **Devin Lange**
 4. How Do Professionals Use Annotations in Visualizations? **Md Dilshadur Rahman**, Ghulam Jilani Quadri, Paul Rosen.
 5. GASP: A Gradient-Aware Shortest Path Algorithm for Boundary-Confined Visualization of 3D Reeb Graphs. **Sefat E Rahman**, Tushar M. Athawale, Paul Rosen
-6. ChannelExplorer: Visual Analytics at Activation Channel‚Äôs Granularity. **Md Rahat-uz- Zaman**, Bei Wang, Paul Rosen
+6. ChannelExplorer: Visual Analytics at Activation Channel's Granularity. **Md Rahat-uz- Zaman**, Bei Wang, Paul Rosen
 7. CrowdAloud: A Platform for Crowd-Sourced Think-Aloud Studies. **Zach Cutler**, Lane Harrison, Carolina Nobre, Alexander Lex
 8. Balancing Code Order and Loop Structure in a Control Flow Layout. **Shadmaan Hye**, Matthew Legendre, Katherine E. Isaacs
 


### PR DESCRIPTION
My poster name seemed to be a mistyped apostrophe on the VIS website. It's harder to fix it there, but easier to fix here, so just did that.

Also, the satellite logo was taking up more than the full screen for wide-screen. Fixed that.